### PR TITLE
Fix: resolve no-quiz-loaded bug in `/correction` page

### DIFF
--- a/web_dynamic/static/scripts/correction.js
+++ b/web_dynamic/static/scripts/correction.js
@@ -1,23 +1,6 @@
 #!/usr/bin/node
-// Properties of the Quiz page
+// Properties of the Corrections page
 $(function () {
-
-	// Get quiz
-	var Quiz = JSON.parse(localStorage.getItem('Quiz'));
-
-	// console.log(Quiz);	// test
-	if (Quiz == null) {
-		console.log('Null quiz');	// test
-		Swal.fire({
-			title: "No quiz loaded 🥺",
-			icon: "error",
-			text: "Sorry, go to Menu >> Take a quiz."
-		}).then((result) => {
-			if (result.isConfirmed) {
-				window.location.assign(`${WEB_BASE_URL}/choose_quiz`);
-			}
-		});
-	}
 
 	// Current item
 	function setCurrent() {


### PR DESCRIPTION
Sweetalert-code-block demanding at least one Quiz to be loaded on local storage was removed as well as the fetch command to the storage. This is not required in `/correction` page but in `/quiz` page.
- Was blindly copied from the `quiz.js` as both pages are similar.

# Before `/correction`
![Before fixing correction page](https://github.com/user-attachments/assets/09505f6b-5da7-45ac-a240-f18358b310a1)

# After `/correction`
![After fixing correction page](https://github.com/user-attachments/assets/a0e788e6-e76e-4fe6-9427-1c75ed0ee15c)

Closes #5 