### PR TITLE
Add color coding for `/correction` page #17

### DIFF
--- a/web_dynamic/static/styles/correction.css
+++ b/web_dynamic/static/styles/correction.css
@@ -1,0 +1,28 @@
+.quiz_numbers .correct {
+    border-color:rgb(231, 111, 13);
+    color:rgb(231, 111, 13);
+}
+
+.quiz_numbers .correct.quiz_num.current {
+    background-color:rgb(231, 111, 13);
+    color:white;
+}
+
+.quiz_numbers .wrong {
+    border-color:rgb(128, 0, 128);
+    color:rgb(128, 0, 128);
+}
+
+.quiz_numbers .wrong.quiz_num.current {
+    background-color:rgb(128, 0, 128);
+    color:white;
+}
+
+.quiz_numbers .not-attempted {
+    color:#484848;
+}
+
+.quiz_numbers .not-attempted.quiz_num.current {
+    background-color:#484848;
+    color:white;
+}

--- a/web_dynamic/templates/correction.html
+++ b/web_dynamic/templates/correction.html
@@ -3,6 +3,7 @@
     {{ super() }}
     <link rel="stylesheet" href="../static/styles/filters.css">
     <link rel="stylesheet" href="../static/styles/quizzes.css">
+    <link rel="stylesheet" href="../static/styles/correction.css">
 {% endblock %}
 
 {% block scripts %}
@@ -25,12 +26,15 @@
 			<!--
                         <li class="attempted">1</li>
                         <li class="current">8</li>
+			Note: quiz_num is a classed used by a function in correction.js for implemting onClick event and action.
 			-->
 		    {% for answer in answers %}
 		    	{% if answer.value < 1 %}
-		    <li id="quiz_num.Question.{{ answer.question.id }}" class="quiz_num" href="Question.{{ answer.question.id }}">{{ loop.index }}</li>
+		    	<li id="quiz_num.Question.{{ answer.question.id }}" class="not-attempted quiz_num" href="Question.{{ answer.question.id }}">{{ loop.index }}</li>
+		    	{% elif answer.value != answer.question.correct_answer %}
+		    	<li id="quiz_num.Question.{{ answer.question.id }}" class="wrong quiz_num" href="Question.{{ answer.question.id }}">{{ loop.index }}</li>
 		    	{% else %}
-		    <li id="quiz_num.Question.{{ answer.question.id }}" class="attempted quiz_num" href="Question.{{ answer.question.id }}">{{ loop.index }}</li>
+		    	<li id="quiz_num.Question.{{ answer.question.id }}" class="correct quiz_num" href="Question.{{ answer.question.id }}">{{ loop.index }}</li>
 		    	{% endif %}
 		    {% endfor %}
                     </ul>


### PR DESCRIPTION
Modified the color coding for the quiz number navigation buttons in the left panel.
- [x] Correctly answered number -> Orange
- [x] Failed number -> Purple
- [x] Unattempted number -> gray

onClicking the numbers, the background color is changed from white to the color code that number bears.
While its font color changes to white.